### PR TITLE
Extended window.navigator instead of overriding it

### DIFF
--- a/socket.io-client.js
+++ b/socket.io-client.js
@@ -1,7 +1,5 @@
 //HACK, socket.io assumes a user agent is defined
-window.navigator = {
-  userAgent: "react-native"
-}
+window.navigator.userAgent: "react-native";
 
 
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.io=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){


### PR DESCRIPTION
By overriding the entire `window.navigator` object to only contain a `userAgent` property, many built-in methods (including `geolocation`) are removed.

This fix extends `window.navigator` with the `userAgent` property while retaining all of its original built-in methods.
